### PR TITLE
Remove stopped containers or untagged images

### DIFF
--- a/docker
+++ b/docker
@@ -25,6 +25,9 @@ docker ps
 # To list all containers:
 docker ps -a
 
+# To remove all stopped containers:
+docker rm $(docker ps -qa)
+
 # To list all images:
 docker images
 

--- a/docker
+++ b/docker
@@ -27,3 +27,6 @@ docker ps -a
 
 # To list all images:
 docker images
+
+# To remove all untagged images:
+docker rmi $(docker images | grep "^<none>" | awk "{print $3}")


### PR DESCRIPTION
Adding two Docker cheats for removing all stopped containers or untagged images.