### PR TITLE
Add cheatsheet for ssh-add and update docker

### DIFF
--- a/docker
+++ b/docker
@@ -33,3 +33,6 @@ docker images
 
 # To remove all untagged images:
 docker rmi $(docker images | grep "^<none>" | awk "{print $3}")
+
+# To remove all volumes not used by at least one container:
+docker volume prune

--- a/ssh-add
+++ b/ssh-add
@@ -1,0 +1,5 @@
+---
+tags: [ ssh ]
+---
+# To store a GitHub SSH passphrase in your keychain:
+ssh-add -K ~/.ssh/github_rsa


### PR DESCRIPTION
Create a cheatsheet for ssh-add which includes a cheat for storing GitHub SSH key passphrases and update the docker cheatsheet to include a cheat for removing unused volumes