### PR TITLE
updated markdown heading synthax

### DIFF
--- a/markdown
+++ b/markdown
@@ -1,8 +1,7 @@
 # headers
-h1 header
-=========
-h2 header
----------
+# (without double qutation marks("))
+"# h1 header"
+"###### h6 header"
 
 # blockquotes
 > first level and paragraph
@@ -27,7 +26,7 @@ regular text
 or:
 Use the `printf()` function
 
-# hr's - three or more of the following
+# hr's (horizontal rules) - three or more of the following
 ***
 ---
 ___


### PR DESCRIPTION
I fixed issue #53 and changed the markdown heading Syntax from the underlining with = and - to # this is because this is more universal. I also added a hint on what a hr (horizontal rule) is.