### PR TITLE
fix(ssh-copy-id): add missing '-i' argument

### DIFF
--- a/ssh-copy-id
+++ b/ssh-copy-id
@@ -8,4 +8,4 @@ ssh-copy-id <user>@<host>
 ssh-copy-id <user>@<host> -p 2222
 
 # To copy a key to a remote host on a non-standard port with non-standard ssh key:
-ssh-copy-id ~/.ssh/otherkey "username@host -p 2222"
+ssh-copy-id -i ~/.ssh/otherkey "username@host -p 2222"


### PR DESCRIPTION
'-i' option requires to select specific ssh key, see ssh-copy-id(1).