### PR TITLE
gpg: Fix highlighting for cht.sh

### DIFF
--- a/gpg
+++ b/gpg
@@ -73,7 +73,7 @@
 
 # Signing and Verifying files
 
-  If you're uploading files to launchpad you may also want to include
+  If you are uploading files to launchpad you may also want to include
   a GPG signature file.
 
     gpg -ba filename


### PR DESCRIPTION
The single quote in "you're" is breaking highlighting of cht.sh.
Rephrase.