### PR TITLE
Apt - fix description of "apt upgrade", warn about careless dist-upgrade

### DIFF
--- a/apt
+++ b/apt
@@ -10,14 +10,15 @@ apt show <package>
 # To fetch package list:
 apt update
 
-# To download and install updates without installing new package:
+# To download and install the updates and (UNLIKE apt-get) install new necessary packages:
 apt upgrade
 
-# To download and install the updates AND install new necessary packages:
+# To download and install the updates AND install new necessary packages
+# AND removing whatever stands in the way of the upgrade - use with caution!
 apt dist-upgrade
 
 # To perform a full system upgrade:
-apt update && apt dist-upgrade
+apt update && apt upgrade # use dist-upgrade carefully if needed
 
 # To install package(s):
 apt install <package>...

--- a/apt-get
+++ b/apt-get
@@ -7,7 +7,8 @@ apt-get update
 # To download and install package updates:
 apt-get upgrade
 
-# To download and install the updates AND install new necessary packages:
+# To download and install the updates AND install new necessary packages
+# AND merciless remove any package that stands in the way of the upgrade.
 apt-get dist-upgrade
 
 # Full command:


### PR DESCRIPTION
I mentioned it in the commits, but it's worth repeating: apt/apt-get dist-upgrade can be dangerous,
it should only be used after a "normal" upgrade, and even then only if the changes it proposes looks reasonable.