### PR TITLE
Update find to show -delete action

### DIFF
--- a/find
+++ b/find
@@ -13,8 +13,11 @@ find . -type f -perm 777
 # To find files with setuid bit set:
 find . -xdev \( -perm -4000 \) -type f -print0 | xargs -0 ls -l
 
-# To find files with extension '.txt' and remove them:
-find ./path/ -name '*.txt' -exec rm '{}' \;
+# To find files with tilde as postfix and remove them:
+find ./path/ -name '*~' -delete
+
+# To find files with extension '.txt' and dump their contents:
+find ./path/ -name '*.txt' -exec cat '{}' \;
 
 # To find files with extension '.txt' and look for a string into them:
 find ./path/ -name '*.txt' | xargs grep 'string'


### PR DESCRIPTION
Using -delete is far more convenient dan -exec for deleting. Added different example for using -exec.