### PR TITLE
docker: Fix double quotes

### DIFF
--- a/docker
+++ b/docker
@@ -32,7 +32,7 @@ docker rm $(docker ps -qa)
 docker images
 
 # To remove all untagged images:
-docker rmi $(docker images | grep "^<none>" | awk "{print $3}")
+docker rmi $(docker images | grep "^<none>" | awk '{print $3}')
 
 # To remove all volumes not used by at least one container:
 docker volume prune


### PR DESCRIPTION
`awk` action statements do not work as expected with double quotes ("), need single quotes instead ('). Example code:

```shell
$ printf "1 2 3" | awk "{print $3}"
1 2 3
$ printf "1 2 3" | awk '{print $3}'
3
```