### PR TITLE
Update tree cheatsheet: Add -a option

### DIFF
--- a/tree
+++ b/tree
@@ -7,5 +7,8 @@ tree <dir>
 # To make tree omit any empty directories from the output:
 tree --prune
 
+# To make tree list *all* files and directories, even hidden ones:
+tree -a
+
 # To list directories only (`-d`), and at a max depth of two levels (`-L`):
 tree -d -L 2


### PR DESCRIPTION
The -a option causes `tree` to show hidden files and folders.
Useful when working with dotfiles repos and the like.