### PR TITLE
Add missing colon

### DIFF
--- a/ed
+++ b/ed
@@ -1,5 +1,5 @@
 ---
-tags [ ed ]
+tags: [ ed ]
 ---
 
 # File and buffer management

--- a/kitty
+++ b/kitty
@@ -1,5 +1,5 @@
 ---
-tags [ kitty ]
+tags: [ kitty ]
 ---
 
 # Scrolling

--- a/vim
+++ b/vim
@@ -1,5 +1,5 @@
 ---
-tags [ vim ]
+tags: [ vim ]
 ---
 
 # File management

--- a/vim-plugins/vim-fzf
+++ b/vim-plugins/vim-fzf
@@ -1,5 +1,5 @@
 ---
-tags [ vim,vim-plugins ]
+tags: [ vim,vim-plugins ]
 ---
 
 # https://github.com/junegunn/fzf.vim

--- a/vim-plugins/vim-goyo
+++ b/vim-plugins/vim-goyo
@@ -1,5 +1,5 @@
 ---
-tags [ vim,vim-plugins ]
+tags: [ vim,vim-plugins ]
 ---
 
 # Toggle Goyo

--- a/vim-plugins/vim-limelight
+++ b/vim-plugins/vim-limelight
@@ -1,5 +1,5 @@
 ---
-tags [ vim,vim-plugins ]
+tags: [ vim,vim-plugins ]
 ---
 
 # https://github.com/junegunn/limelight.vim

--- a/vim-plugins/vim-markdown
+++ b/vim-plugins/vim-markdown
@@ -1,5 +1,5 @@
 ---
-tags [ vim,vim-plugins,markdown ]
+tags: [ vim,vim-plugins,markdown ]
 ---
 
 # https://github.com/plasticboy/vim-markdown


### PR DESCRIPTION
This errors are being silently ignored by go-yaml.

Example, without colon:

~~~
$ grep ^tags /home/user/.config/cheat/cheatsheets/community/kitty
tags [ kitty ]

$ cheat -t kitty
$
~~~

Adding missing colon:
~~~
$ grep ^tags /home/user/.config/cheat/cheatsheets/community/kitty
tags: [ kitty ]

$ cheat -t kitty
title: file:                                                 tags:
kitty  /home/user/.config/cheat/cheatsheets/community/kitty community,kitty
~~~

