### PR TITLE
rm wrong items in `find`

### DIFF
--- a/find
+++ b/find
@@ -61,10 +61,7 @@ find . -type f -samefile MY_FILE_HERE 2>/dev/null
 find . -type f -exec chmod 644 {} \;
 
 # To find all files changed in last 2 days:
-find . -type f -ctime -48h
 find . -type f -ctime -2
-# Or created in last 2 days:
-find . -type f -Btime -2
 # Or accessed in last 2 days:
 find . -type f -atime -2
 


### PR DESCRIPTION
```
find --version
find (GNU findutils) 4.9.0
```

```
 find . -type f -ctime -48h
find: invalid argument `-48h' to `-ctime'
```

```
find . -type f -Btime -2
find: unknown predicate `-Btime'
```