### PR TITLE
Add Command Line Interface Page project support

### DIFF
--- a/clip-view
+++ b/clip-view
@@ -1,20 +1,20 @@
-# To render specific local pages
+# To render specific local pages:
 clip-view <path/to/page1.clip path/to/page2.clip ...>
 
-# To render specific remote pages
+# To render specific remote pages:
 clip-view <page_name1 page_name2 ...>
 
-# To render pages by a specific render
+# To render pages by a specific render:
 clip-view --render <tldr|tldr-colorful|docopt|docopt-colorful> <page_name1 page_name2 ...>
 
-# To render pages with a specific color theme
+# To render pages with a specific color theme:
 clip-view --theme <path/to/local_theme.yaml|remote_theme_name> <page_name1 page_name2 ...>
 
-# To clear a page or theme cache
+# To clear a page or theme cache:
 clip-view --clear-<page|theme>-cache
 
-# To display help
+# To display help:
 clip-view --help
 
-# To display version
+# To display version:
 clip-view --version

--- a/clip-view
+++ b/clip-view
@@ -1,0 +1,20 @@
+# To render specific local pages
+clip-view <path/to/page1.clip path/to/page2.clip ...>
+
+# To render specific remote pages
+clip-view <page_name1 page_name2 ...>
+
+# To render pages by a specific render
+clip-view --render <tldr|tldr-colorful|docopt|docopt-colorful> <page_name1 page_name2 ...>
+
+# To render pages with a specific color theme
+clip-view --theme <path/to/local_theme.yaml|remote_theme_name> <page_name1 page_name2 ...>
+
+# To clear a page or theme cache
+clip-view --clear-<page|theme>-cache
+
+# To display help
+clip-view --help
+
+# To display version
+clip-view --version

--- a/md-to-clip
+++ b/md-to-clip
@@ -1,0 +1,11 @@
+# To convert tldr-pages files and save into the same directories:
+md-to-clip <path/to/page1.md path/to/page2.md ...>
+
+# To convert tldr-pages files and save into a specific directory:
+md-to-clip --output-directory <path/to/directory> <path/to/page1.md path/to/page2.md ...>
+
+# To display help:
+md-to-clip --help
+
+# To display version:
+md-to-clip --version


### PR DESCRIPTION
## Description

[Here](https://command-line-interface-pages.github.io/site.github.io/about/) is a project page. You can find render and converter in [this](https://github.com/command-line-interface-pages/v2-tooling) repo.

![image](https://user-images.githubusercontent.com/42812113/222954208-e10a0fbb-8214-4af7-ae10-9ac694f18ca6.png)


## Notes

Project is already [has](https://github.com/tldr-pages/tldr/pull/9845) support in TlDr. Besides it there is a page for CLIP in [rstacruz/cheatsheets](https://github.com/rstacruz/cheatsheets/pull/1953).