### PR TITLE
openssl: Fix default https port

### DIFF
--- a/openssl
+++ b/openssl
@@ -27,7 +27,7 @@ openssl x509 -noout -enddate
 openssl dhparam -outform PEM -out dhparams.pem 2048
 
 # To test an https server:
-openssl s_client -connect 10.240.2.130:433
+openssl s_client -connect 10.240.2.130:443
 
 # High-quality options for openssl for symmetric (secret key) encryption
   


### PR DESCRIPTION
433 looks like a typo, if someone wants to test a https server with this, it'll fail due to wrong port :)